### PR TITLE
Potential fix for code scanning alert no. 6: Use of insecure SSL/TLS version

### DIFF
--- a/integrations/osint.py
+++ b/integrations/osint.py
@@ -91,6 +91,7 @@ def ssl_cert_info(
     host: str, port: int = 443, timeout: float = 5.0
 ) -> Optional[SSLCertInfo]:
     ctx = ssl.create_default_context()
+    ctx.minimum_version = ssl.TLSVersion.TLSv1_2
     try:
         with socket.create_connection((host, port), timeout=timeout) as sock:
             with ctx.wrap_socket(sock, server_hostname=host) as ssock:


### PR DESCRIPTION
Potential fix for [https://github.com/Into-The-Grey/Vega2.0/security/code-scanning/6](https://github.com/Into-The-Grey/Vega2.0/security/code-scanning/6)

The best fix is to explicitly require secure protocol versions (TLSv1.2 or newer) when creating the SSL context. Python 3.7+ allows setting `minimum_version` on the context, while earlier versions can achieve this via context options with `OP_NO_TLSv1` and `OP_NO_TLSv1_1`. Since the code creates the SSL context on line 93 (`ctx = ssl.create_default_context()`), update the subsequent lines to set `ctx.minimum_version = ssl.TLSVersion.TLSv1_2` (Python 3.7+/OpenSSL 1.1+) or use `ctx.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1` as a fallback if broader compatibility is needed. Given the code appears modern, favor the `minimum_version` approach.

Edit only the relevant region in `integrations/osint.py`: lines 93–94, to restrict the SSL context’s minimum version to TLSv1.2.

No new imports or external libraries are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
